### PR TITLE
Add folder support, fix submesh bug

### DIFF
--- a/Model.cs
+++ b/Model.cs
@@ -8,6 +8,7 @@ using Toolbox.Core.IO;
 using OpenTK;
 using IONET.Core.Model;
 using IONET.Core;
+using System.IO;
 
 namespace TTLibrary
 {
@@ -27,6 +28,8 @@ namespace TTLibrary
             while (reader.BaseStream.Length > reader.Position) {
                 long pos = reader.Position;
                 var chunk = reader.ReadStruct<ResourceChunk>();
+                Console.WriteLine("=============");
+                Console.WriteLine($"Read chunk: size {chunk.Size}, type: {new string(chunk.Type)}, version: {chunk.Version}" );
                 ParseChunk(reader, chunk);
                 reader.SeekBegin(pos + chunk.Size + 4);
             }
@@ -38,10 +41,14 @@ namespace TTLibrary
             switch (type)
             {
                 case ".CC4HSERHSER": //Resource Hierarchy
-                    reader.ReadZeroTerminatedString();
+                    Console.WriteLine("Reading resource hierarchy (CC4HSERHSER)");
+                    string bla = reader.ReadZeroTerminatedString();
+                    Console.WriteLine($"-- \"{bla}\"");
                     Name = ReadString(reader);
+                    Console.WriteLine($"Name: \"{Name}\"");
                     break;
                 case ".CC4HSER2CSG": //Scene Data
+                    Console.WriteLine("Reading scene data (CC4HSER2CSG)");
                     ParseCSG(reader);
                     break;
             }
@@ -53,38 +60,72 @@ namespace TTLibrary
             model.Name = "Model";
 
             uint numMaterials = reader.ReadUInt32();
+            Console.WriteLine($"numMaterials: \"{numMaterials}\"");
             ushort unk = reader.ReadUInt16();
+            Console.WriteLine($"unk: \"{unk}\"");
             reader.ReadInt16(); //padding
 
             //Read materials first
+            Console.WriteLine($"Reading materials...");
             Material[] materials = new Material[numMaterials];
             for (int i = 0; i < numMaterials; i++)
             {
+                Console.WriteLine($"\t---");
+                Console.WriteLine($"\tStart at {reader.Position.ToString("X")}");
                 materials[i] = new Material();
+                reader.ReadChar(); // Padding
                 materials[i].FilePath = ReadString(reader);
+
+                Console.WriteLine($"\tPadding 1 [1] at {reader.Position.ToString("X")}");
+                reader.ReadChar(); // Padding
                 materials[i].Name = ReadString(reader);
-                reader.Seek(3);
+
+                Console.WriteLine($"\tPadding 2 [3] at {reader.Position.ToString("X")}");
+                string padding2 = new string(reader.ReadChars(3));
+                Console.WriteLine($"\tMaterial {materials[i].Name} at {materials[i].FilePath}");
             }
+
+            Console.WriteLine($"Reading sub meshes...");
+            Console.WriteLine($"\tStart at {reader.Position.ToString("X")}");
+            Console.WriteLine($"\tPadding 1 [UInt32] at {reader.Position.ToString("X")}");
             //Next is the sub meshes.
             reader.ReadUInt32(); //padding
             uint numMeshes = reader.ReadUInt32();
+            Console.WriteLine($"\tnumMeshes: {numMeshes}");
+            Console.WriteLine($"\tPadding 1 [UInt32] at {reader.Position.ToString("X")}");
             reader.ReadUInt32(); //1
 
             SubMesh[] meshes = new SubMesh[numMeshes];
             for (int i = 0; i < numMeshes; i++)
             {
-                meshes[i] = reader.ReadStruct<SubMesh>();
+                // Make sure we're starting this mesh at the right place
+                SeekToSMNR(reader, 128, 0);
 
+				Console.WriteLine($"Reading mesh {i+1}/{numMeshes}...");
+                Console.WriteLine($"\tRead submesh at {reader.Position.ToString("X")}");
+                meshes[i] = reader.ReadStruct<SubMesh>();
+                Console.WriteLine($"\tSubmesh:");
+                Console.WriteLine($"\t\tmagic {meshes[i].Magic}");
+                Console.WriteLine($"\t\tNumBuffers {meshes[i].NumBuffers}");
+                Console.WriteLine($"\t\tNumVerts {meshes[i].NumVerts}");
+                Console.WriteLine($"\t\tVersion {meshes[i].Version}");
+                Console.WriteLine($"\t\tUnknown1 {meshes[i].Unknown1}");
+                Console.WriteLine($"\t\tUnknown2 {meshes[i].Unknown2}");
+
+                Console.WriteLine($"\t\tParse DXTV at {reader.Position.ToString("X")}");
                 Buffer[] buffers = ParseDXTV(reader, meshes[i]);
 
                 //Indices come after all the buffer DXTVs
                 uint numIndices = reader.ReadUInt32();
+                Console.WriteLine($"\tnumIndices {numIndices}");
                 uint indexFormat = reader.ReadUInt32(); //2 for ushort
+                Console.WriteLine($"\tindexFormat {indexFormat}");
 
                 if (indexFormat != 2 && indexFormat != 4)
                     throw new Exception($"Unknown index format! {indexFormat}");
 
                 reader.SetByteOrder(false);
+                Console.WriteLine($"\tRead indices at {reader.Position.ToString("X")}");
 
                 uint[] indices = new uint[numIndices];
                 for (int j = 0; j < numIndices; j++)
@@ -95,48 +136,152 @@ namespace TTLibrary
 
                 reader.SetByteOrder(true);
                 //70 extra bytes we need to skip till the next sub mesh section
-                reader.Seek(70 + 4 * buffers.Length);
-                //Convert the buffers and indices to a usable .iomesh to make a .dae file
-                model.Meshes.Add(ConvertToDae(meshes[i],i, buffers, indices));
-            }
+                Console.WriteLine($"\tPadding {70} bytes at {reader.Position.ToString("X")}");
+                reader.Seek(70);
+
+				if (i < numMeshes + 1)
+                {
+					// Try to find the "SMNR" string that starts the next submesh, looking through the next 128 bytes.
+					// If we don't find it, default to skipping the next (4 * buffers.Length) bytes.
+					SeekToSMNR(reader, 128, 4 * buffers.Length);
+				}
+
+				//Convert the buffers and indices to a usable .iomesh to make a .dae file
+				Console.WriteLine($"\tConverting to DAE");
+				model.Meshes.Add(ConvertToDae(meshes[i], i, buffers, indices));
+			}
             //Convert to ioscene and export as .dae
             var scene = new IOScene();
             scene.Models.Add(model);
 
-            //Todo no material support atm
-            foreach (var mat in materials)
-            {
-               /* scene.Materials.Add(new IOMaterial() {
-                    Name = mat.Name,
-                });*/
-            }
-            IONET.IOManager.ExportScene(scene, $"{System.IO.Path.GetFileNameWithoutExtension(Name)}.dae");
+            Console.WriteLine($"=============");
+            // Name is "-Assets/Core/RopeAssets/ledge_end2_dx11.model"
+            // There's a random character before the folder name that needs to be removed
+            Console.WriteLine($"{Name}");
+            var relativePath = Name.Remove(0,1);
+            // relativePath == "Assets/Core/RopeAssets/ledge_end2_dx11.model"
+            relativePath = relativePath.Replace("/","\\");
+            // relativePath == "Assets\Core\RopeAssets\ledge_end2_dx11.model"
+            var extractedFolder = "C:\\Users\\Vini\\Desktop\\TSS\\NTT-Model-Dumper-main\\bin\\Debug\\net5.0\\Extracted";
+            var newPath = System.IO.Path.Combine(extractedFolder, relativePath);
+            // newPath == "G:\Extracted\Assets\Core\RopeAssets\ledge_end2_dx11.model"
+            Console.WriteLine($"{newPath}");
+            var outputPath = System.IO.Path.ChangeExtension(newPath, "dae");
+            // outputPath == "G:\Extracted\Assets\Core\RopeAssets\ledge_end2_dx11.dae"
+            Console.WriteLine($"{outputPath}");
+            var outputFolder = System.IO.Path.GetDirectoryName(outputPath);
+            // outputPath == "G:\Extracted\Assets\Core\RopeAssets"
+            Console.WriteLine($"{outputFolder}");
+
+            // Create the folder (fails silently if it already exists)
+            System.IO.Directory.CreateDirectory(outputFolder);
+
+            // Export the file
+            IONET.IOManager.ExportScene(scene, outputPath);
 
             Console.WriteLine();
         }
 
-        private Buffer[] ParseDXTV(FileReader reader, SubMesh mesh)
+        public void SeekToSMNR(FileReader reader, int maximumOffest, int fallbackOffset)
         {
+			Console.WriteLine($"\tLooking for SMNR from {reader.Position.ToString("X")} through the next {maximumOffest} bytes");
+
+			// The next submesh section starts with an SMNR string, which has some unknown padding before it
+			int searchIndex = 1;
+			int k = 0;
+			String SMNR = "SMNR";
+			for (searchIndex = 1; searchIndex <= maximumOffest; searchIndex++)
+			{
+                try
+                {
+                    int character = reader.ReadChar();
+
+					if (character == SMNR[k])
+					{
+						k++;
+						// If we finished reading the SMNR string
+						if (k == 4)
+						{
+							// Reset the reader's position to just before the SMNR string
+							reader.Seek(-4);
+							Console.WriteLine($"\tNext SMNR starts at {reader.Position.ToString("X")}");
+							break;
+						}
+					}
+				}
+                catch (EndOfStreamException)
+                {
+                    // Leave the for loop and use the fallback offset instead
+                    k = 0;
+                    break;
+                }
+			}
+			if (k != 4)
+			{
+				// If we didn't manually find the SMNR string, try rewinding the SMNR search (by j bytes) and instead
+				// advancing to the fallback offset
+				int seekOffset = -searchIndex + fallbackOffset;
+				Console.WriteLine($"\tDidn't find SMNR, seeking by {seekOffset} bytes from {reader.Position.ToString("X")}");
+				reader.Seek(seekOffset);
+				Console.WriteLine($"\tSeek complete, starting at {reader.Position.ToString("X")}");
+			}
+		}
+
+		public string ReadSignature(FileReader reader, int length, string ExpectedSignature, bool TrimEnd = false)
+		{
+			string text = reader.ReadString(length, Encoding.ASCII);
+            Console.WriteLine(text);
+			if (TrimEnd)
+			{
+				Console.WriteLine("Trimming");
+				text = text.TrimEnd(' ');
+				Console.WriteLine("Trimmed");
+			}
+
+			if (text != ExpectedSignature)
+			{
+                Console.WriteLine("Throwing");
+				throw new Exception("Invalid signature " + text + "! Expected " + ExpectedSignature + ".");
+			}
+
+			Console.WriteLine("Returning");
+			return text;
+		}
+
+		private Buffer[] ParseDXTV(FileReader reader, SubMesh mesh)
+        {
+            Console.WriteLine($"\tStarting DXTV at {reader.Position.ToString("X")}");
             Buffer[] buffers = new Buffer[mesh.NumBuffers];
             for (int i = 0; i < mesh.NumBuffers; i++)
             {
                 Buffer buffer = new Buffer();
                 buffers[i] = buffer;
 
-                reader.ReadSignature(4, "DXTV");
-                uint version = reader.ReadUInt32();
-                uint numAttributes = reader.ReadUInt32();
+                Console.WriteLine($"\tBuffer {i+1}/{mesh.NumBuffers} at {reader.Position.ToString("X")}");
+
+				ReadSignature(reader, 4, "DXTV");
+				uint version = reader.ReadUInt32();
+				uint numAttributes = reader.ReadUInt32();
+				Console.WriteLine($"\t\tVersion {version}");
+                Console.WriteLine($"\t\tnumAttributes: {numAttributes}");
 
                 buffer.Attributes = new Attribute[numAttributes];
-                for (int j = 0; j < numAttributes; j++)
+                for (int j = 0; j < numAttributes; j++) {
+                    Console.WriteLine($"\t\tAttribute {j+1}/{numAttributes}");
                     buffer.Attributes[j] = new Attribute()
                     {
                         Type = (AttributeType)reader.ReadByte(),
                         Format = (AttributeFormat)reader.ReadByte(),
                         Offset = reader.ReadByte(),
                     };
+                    Console.WriteLine($"\t\t\ttype: {buffer.Attributes[j].Type}");
+                    Console.WriteLine($"\t\t\tformat: {buffer.Attributes[j].Format}");
+                    Console.WriteLine($"\t\t\toffset: {buffer.Attributes[j].Offset}");
+                }
 
+                Console.WriteLine($"\t\tPadding 6 at {reader.Position.ToString("X")}");
                 reader.Seek(6);
+                Console.WriteLine($"\t\tParse vertices starting at {reader.Position.ToString("X")}");
                 var stride = buffer.Attributes.Sum(x => x.GetStride());
 
                 for (int j = 0; j < numAttributes; j++)
@@ -153,8 +298,10 @@ namespace TTLibrary
                 }
                 reader.SetByteOrder(true);
 
+                Console.WriteLine($"\t\tSeek begin for {pos + stride * mesh.NumVerts + 16} bytes at {reader.Position.ToString("X")}");
                 reader.SeekBegin(pos + stride * mesh.NumVerts + 16);
             }
+            Console.WriteLine($"\tFinished DXTV at {reader.Position.ToString("X")}");
             return buffers;
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace TTLibrary
 {
@@ -17,13 +18,50 @@ namespace TTLibrary
                 return;
             }
 
-            if (!args[0].ToLower().EndsWith(".model"))
-            {
-                Console.WriteLine($"Input file must be a .model.");
-                return;
+            foreach (var argument in args) {
+                Console.WriteLine($"Handling argument {argument}");
+                Program.HandleFile(argument);
             }
+        }
 
-            Model model = new Model(args[0]);
+        static void HandleFile(string path) {
+            Console.WriteLine($"\tHandling path {path}");
+            FileAttributes attributes = File.GetAttributes(path);
+
+            switch (attributes)
+            {
+                case FileAttributes.Directory:
+                    if (Directory.Exists(path)) {
+                        Console.WriteLine($"\t\tDirectory start");
+                        string[] files = Directory.GetFiles(path, "*.MODEL", SearchOption.AllDirectories);
+                        foreach (var file in files) {
+                            Program.HandleFile(file);
+                        }
+                        Console.WriteLine($"\t\tDirectory done");
+                    }
+                    else
+                        Console.WriteLine($"Directory {path} does not exist.");
+                    break;
+                default:
+                    if (File.Exists(path)) {
+                        Console.WriteLine($"Trying file {path}");
+                        if (!path.ToLower().EndsWith(".model"))
+                        {
+                            Console.WriteLine($"Input file must be a .MODEL.");
+                            return;
+                        }
+
+                        try {
+                            Model model = new Model(path);
+                        }
+                        catch (Exception e) {
+                            
+                        }
+                    }
+                    else
+                        Console.WriteLine("This file does not exist.");
+                    break;
+            }
         }
     }
 }


### PR DESCRIPTION
Honestly, this contains a bunch of small changes I've made over the last few years, and I don't fully remember everything I did, but looking at the code the main differences I see are:

- Add a bunch of output text to make it easier to debug.
- Support receiving multiple files as input, or even folders, to export everything at once.
- Files are now extracted into an `./Extracted` folder, and inside it they follow the game's folder structure (based on information contained within the file). For instance, the file `<path to TSS folder>/ASSETS/ENVART/LEVELS/HUB/PLANETS/TATOOINE/LOCATIONS/SHARED_ASSETS/ROCKFACETALL_C_DX11.MODEL` would be extracted into `<path to executable>/Extracted/Assets/EnvArt/Levels/Hub/Planets/Tatooine/Locations/Shared_Assets/RockFaceTall_C_dx11.dae`. This also means we can now extract many files at once (potentially the whole game) and the output files will keep their folder structure and should be easy to find.
- Fix a bug where some models weren't being extracted correctly (e.g. the `ROCKFACETALL_C_DX11.MODEL` above) because the program tried to start parsing the submesh from the wrong place. In my tests this fix worked for several other models and didn't break any existing model, but I haven't tested all the models in the game, so it's possible there will be some regressions from this. In any case I'll keep using this code and will fix any errors I find in this logic.